### PR TITLE
Allow installation of SA-Telemetry on OpenShift 3.10

### DIFF
--- a/examples/61will.space_dev/inventory/openshift-ansible/telemetry.inventory
+++ b/examples/61will.space_dev/inventory/openshift-ansible/telemetry.inventory
@@ -26,7 +26,7 @@ openshift_storage_glusterfs_storageclass_default=true
 
 # service broker
 openshift_enable_service_catalog=true
-openshift_service_catalog_image_version=v3.9
+openshift_service_catalog_image_version=v3.10
 
 # logging control
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 4", "size 50M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
@@ -35,10 +35,10 @@ journald_vars_to_replace=[{ "var": "Storage", "val": "persistent" },{ "var": "Co
 
 # main setup
 openshift_disable_check=disk_availability,memory_availability,docker_image_availability,package_version
-openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider'}]
 openshift_deployment_type=origin
-openshift_release=v3.9
-openshift_pkg_version=-3.9.0-1.el7.git.0.ba7faec
+openshift_release=v3.10
+openshift_pkg_version=-3.10.0-1.el7.git.0.0c4577e
 enable_excluders=false
 openshift_clock_enabled=true
 
@@ -58,6 +58,10 @@ ansible_service_broker_registry_organization=ansibleplaybookbundle
 ansible_service_broker_registry_whitelist=[".*-apb$"]
 ansible_service_broker_local_registry_whitelist=[".*"]
 
+# define node groups
+openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']}, {'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true']}, {'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true','node=blue','application=sa-telemetry']}]
+
+
 [masters]
 openshift-master-1
 
@@ -65,10 +69,10 @@ openshift-master-1
 openshift-master-1
 
 [nodes]
-openshift-master-1 openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
-openshift-node-1 openshift_node_labels="{'region': 'primary', 'zone': 'default', 'node': 'blue', 'application': 'sa-telemetry'}"
-openshift-node-2 openshift_node_labels="{'region': 'primary', 'zone': 'default', 'node': 'blue', 'application': 'sa-telemetry'}"
-openshift-infra-node-1 openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+openshift-master-1 openshift_node_group_name='node-config-master'
+openshift-node-1 openshift_node_group_name='node-config-compute'
+openshift-node-2 openshift_node_group_name='node-config-compute'
+openshift-infra-node-1 openshift_node_group_name='node-config-infra'
 
 [glusterfs]
 openshift-master-1

--- a/patches/components.yml.patch
+++ b/patches/components.yml.patch
@@ -1,11 +1,11 @@
 diff --git a/playbooks/common/private/components.yml b/playbooks/common/private/components.yml
-index 089645d07..bc47861ab 100644
+index c5627be..1b56ee8 100644
 --- a/playbooks/common/private/components.yml
 +++ b/playbooks/common/private/components.yml
-@@ -36,3 +36,6 @@
+@@ -51,3 +51,6 @@
  
- - import_playbook: ../../openshift-management/private/config.yml
-   when: openshift_management_install_management | default(false) | bool
+ - import_playbook: ../../openshift-autoheal/private/config.yml
+   when: openshift_autoheal_deploy | default(false) | bool
 +
 +- import_playbook: ../../sa-telemetry/private/config.yml
 +  when: sa_telemetry_install | default(false) | bool

--- a/playbooks/sa-telemetry/private/config.yml
+++ b/playbooks/sa-telemetry/private/config.yml
@@ -3,11 +3,13 @@
   hosts: all
   gather_facts: false
   tasks:
-  - name: Set Telemetry install 'In Progress'
+  - name: Set SA Telemetry install 'In Progress'
     run_once: true
     set_stats:
       data:
         installer_phase_sa_telemetry:
+          title: "SA Telemetry Install"
+          playbook: "playbooks/sa-telemetry/config.yml"
           status: "In Progress"
           start: "{{ lookup('pipe', 'date +%Y%m%d%H%M%SZ') }}"
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,7 +2,7 @@
 
 BASE_INFRA_BOOTSTRAP_GIT_REPO="https://github.com/redhat-nfvpe/base-infra-bootstrap"
 OPENSHIFT_GIT_REPO="https://github.com/openshift/openshift-ansible"
-OPENSHIFT_BRANCH="openshift-ansible-3.9.39-1"
+OPENSHIFT_BRANCH="openshift-ansible-3.10.38-1"
 _TOPDIR=`pwd`
 
 echo "-- Create working directory"

--- a/scripts/demo_setup.sh
+++ b/scripts/demo_setup.sh
@@ -34,6 +34,9 @@ pushd working/base-infra-bootstrap
         playbooks/vm-teardown.yml \
         playbooks/virt-host-setup.yml
 
+#*** load ssh keys into memory from vars
+    ansible -c local -e "@./inventory/nodes.vars" -m raw -a 'ssh-add {{ vm_ssh_key_path }}' localhost
+
 #*** wait for nodes to come up
     ansible -i inventory/vms.local.generated -m wait_for \
         -a "port=22 host='{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}' search_regex=OpenSSH delay=10" \


### PR DESCRIPTION
Allow installation of telemetry-framework on OpenShift 3.10. I'm merging this against a new branch `devel` so that `master` doesn't substantially change right now.