### PR TITLE
Pass uname arg to metrics consumer

### DIFF
--- a/roles/sa_telemetry_consumers/templates/metrics-consumer-deployment.yaml.j2
+++ b/roles/sa_telemetry_consumers/templates/metrics-consumer-deployment.yaml.j2
@@ -24,7 +24,15 @@ spec:
           limits:
             memory: {{ sa_telemetry_metrics_memory_limit }}
             cpu: {{ sa_telemetry_metrics_cpu_limit }}
-        args: ["-config=/config/sa.metrics.config.json"]
+        args:
+          - '-config=/config/sa.metrics.config.json'
+          - '-uname=$(MY_POD_NAME)'
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
         ports:
         - name: metrics
           containerPort: 8081


### PR DESCRIPTION
This passes the uname argument for the metrics consumer so that the consumer
is loading with a unique name in k8s.