### PR TITLE
Set _TOPDIR on the bootstrap script correctly

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,7 +3,7 @@
 BASE_INFRA_BOOTSTRAP_GIT_REPO="https://github.com/redhat-nfvpe/base-infra-bootstrap"
 OPENSHIFT_GIT_REPO="https://github.com/openshift/openshift-ansible"
 OPENSHIFT_BRANCH="openshift-ansible-3.9.39-1"
-_TOPDIR=`pwd`
+_TOPDIR=$(dirname `readlink -f -- $0`)/..
 
 echo "-- Create working directory"
 if [ ! -d working ]; then


### PR DESCRIPTION
The current _TOPDIR=`pwd` directive makes the bootscript fail when it's not running on a specific path telemetry-framework.

The proposal makes the script work no matter where the script is run.